### PR TITLE
fix: Update firehose start command to use all permissions

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -4,7 +4,7 @@
     "dev:firehose": "deno run --watch --env -A ./src/firehose/index.ts",
     "build": "next build",
     "start:next": "next start",
-    "start:firehose": "deno run --env --allow-net ./src/firehose/index.ts",
+    "start:firehose": "deno run --env -A ./src/firehose/index.ts",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",
     "lint": "biome lint",


### PR DESCRIPTION
Changes start:firehose task from --allow-net to -A flag for full permissions to match dev:firehose configuration.

🤖 Generated with [Claude Code](https://claude.ai/code)